### PR TITLE
Fix positive NaNs not classified correctly

### DIFF
--- a/src/is_special_float.v
+++ b/src/is_special_float.v
@@ -42,8 +42,8 @@ module is_special_float #(
     assign is_infinite = is_E4M3 || is_E2M3 || is_E3M2 || is_E2M1 ? 1'b0 : is_exponent_ones && is_mantissa_zero;
     assign is_zero = is_exponent_zero && is_mantissa_zero;
     assign is_subnormal = is_exponent_zero && !is_mantissa_zero;
-    assign is_signaling_nan = is_E2M3 || is_E3M2 || is_E2M1 ? 1'b0 : (is_E4M3 ? is_exponent_ones && is_mantissa_ones : is_negative && is_exponent_ones && (mantissa[MANTISSA_WIDTH-1] == 1'b1));
-    assign is_quiet_nan = is_E4M3 || is_E2M3 || is_E3M2 || is_E2M1 ? 1'b0 : is_negative && is_exponent_ones && (mantissa[MANTISSA_WIDTH-1] == 1'b0) && !is_mantissa_zero;
+    assign is_signaling_nan = is_E2M3 || is_E3M2 || is_E2M1 ? 1'b0 : (is_E4M3 ? is_exponent_ones && is_mantissa_ones : is_exponent_ones && (mantissa[MANTISSA_WIDTH-1] == 1'b1));
+    assign is_quiet_nan = is_E4M3 || is_E2M3 || is_E3M2 || is_E2M1 ? 1'b0 : is_exponent_ones && (mantissa[MANTISSA_WIDTH-1] == 1'b0) && !is_mantissa_zero;
 endmodule
 
 `endif

--- a/test/tests/floating_point_multiplier_tests.py
+++ b/test/tests/floating_point_multiplier_tests.py
@@ -61,7 +61,9 @@ async def test_nan(dut):
     if is_IEEE_754_32_bit_float(dut):
         QNAN = 0xFFC00000
         SNAN = 0xFFA00000
+        ALSO_QNAN = 0b0_11111111_00000000000000000000001
 
+        await check_input_combo(dut, ALSO_QNAN, 0x40800000, QNAN, (0, 0, 1), "QNaN * 4.0 != QNaN")
         await check_input_combo(dut, QNAN, 0x40800000, QNAN, (0, 0, 1), "QNaN * 4.0 != QNaN")
         await check_input_combo(dut, SNAN, 0x40800000, QNAN, (0, 0, 1), "SNaN * 4.0 != QNaN")
     elif is_IEEE_754_64_bit_float(dut) or is_16_bit_float(dut):


### PR DESCRIPTION
NaNs with a positive sign were not being classified correctly. For the purpose of classifying NaNs, the sign bit does not matter.